### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Links to other lists of packages are in **bold**.
 
    * [particle](https://github.com/scikit-hep/particle): particle data, such as masses and PDG properties
    * [decaylanguage](https://github.com/scikit-hep/decaylanguage)
-   * [MadMiner](https://github.com/johannbrehmer/madminer): Likelihood fits to high-dimensional observables (multi-differential distributions) using Machine-learning techniques.
+   * [MadMiner](https://github.com/diana-hep/madminer): Likelihood fits to high-dimensional observables (multi-differential distributions) using Machine-learning techniques.
 
 ### Data access
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Links to other lists of packages are in **bold**.
 ### Reproducibility, reinterpretation
 
    * [Rivet](https://rivet.hepforge.org)
-   * [RECAST](http://recast.perimeterinstitute.ca) - [talk](https://indico.cern.ch/event/639314/contributions/2726367/attachments/1542484/2419628/ReinterpretationWorkshopFNAL.pdf)
+   * [RECAST](https://recast-docs.web.cern.ch) - [talk](https://indico.cern.ch/event/639314/contributions/2726367/attachments/1542484/2419628/ReinterpretationWorkshopFNAL.pdf)
    * [MadAnalysis](https://madanalysis.irmp.ucl.ac.be)
    * [CheckMate](http://checkmate.hepforge.org/)
    * [Contour](https://contur.hepforge.org)


### PR DESCRIPTION
This PR updates a couple of resource links.

NOTE: For the case of RECAST, the desired URL would be https://recast.cern.ch/, same as in the [IRIS-HEP projects page](https://iris-hep.org/projects/recast.html). However, that seems to be down, so I am proposing  ATLAS documentation page as an alternative.